### PR TITLE
Update generator.yaml

### DIFF
--- a/forge-1.12.2/generator.yaml
+++ b/forge-1.12.2/generator.yaml
@@ -2,7 +2,7 @@ name: Minecraft Forge for @minecraft (@buildfileversion)
 basefeatures: [~variables, model_json, model_obj, model_java, i18n, structures, textures, sounds]
 partial_support: [loottable, recipe, block, achievement, mob, keybind]
 status: deprecated
-buildfileversion: 14.23.5.2855
+buildfileversion: 14.23.5.2860
 subversion: 4.0
 
 start_id_map:


### PR DESCRIPTION
Updated generator.yaml to Forge 14.23.5.2860, to fix the log4j security issue inside the generator. The log4j security issue was fixed with Forge 14.23.5.2856 and above, so I updated the generator to the newest Forge 1.12.2 version! In the current generator version 143.23.5.2855 is the log4j security issue still active and that's not good because it opens up the ability for hackers to destroy the computer or read e-mails / messages for example.